### PR TITLE
ENTESB-14969 Link Secrets Creation page to Quickstarts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,15 +31,15 @@ The most effective way to run this quickstart is to deploy and run the project o
 
 For more details about running this quickstart on a single-node OpenShift cluster, CI/CD deployments, as well as the rest of the runtime, see the link:http://appdev.openshift.io/docs/spring-boot-runtime.html[Spring Boot Runtime Guide].
 
-== Running the Quickstart on a single-node Kubernetes/OpenShift cluster
+== Running the Quickstart on a single-node Kubernetese/OpenShift cluster
 
 IMPORTANT: You need to run this example on Container Development Kit 3.3 or OpenShift 3.7.
 Both of these products have suitable Fuse images pre-installed.
 If you run it in an environment where those images are not preinstalled follow the steps described in <<single-node-without-preinstalled-images>>.
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -57,8 +57,6 @@ $ oc new-project MY_PROJECT_NAME
 
 . Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/spring-boot-camel-rest-3scale`) :
 +
-or
-+
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ cd my_openshift/spring-boot-camel-rest-3scale
@@ -68,23 +66,22 @@ $ cd my_openshift/spring-boot-camel-rest-3scale
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests fabric8:deploy -Popenshift
+$ mvn clean -DskipTests oc:deploy -Popenshift
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
 Wait until you can see that the pod for the `spring-boot-camel-rest-3scale` has started up.
 
-. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-rest-3scale` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/pods/spring-boot-camel-rest-3scale-NUMBER_OF_DEPLOYMENT?tab=details`.
+. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-rest-3scale` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-rest-3scale-NUMBER_OF_DEPLOYMENT?tab=details`.
 
-. Switch to tab `Logs` and then see the log from Camel.
+. Switch to tab `Logs` and then see the messages sent by Camel.
 
 [#single-node-without-preinstalled-images]
-=== Running the Quickstart on a single-node Kubernetes/OpenShift cluster without preinstalled images
+=== Running the Quickstart on a single-node Kubernetese/OpenShift cluster without preinstalled images
 
-A single-node Kubernetes/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
+A single-node Kubernetese/OpenShift cluster provides you with access to a cloud environment that is similar to a production environment.
 
-If you have a single-node Kubernetes/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
-
+If you have a single-node Kubernetese/OpenShift cluster, such as Minishift or the Red Hat Container Development Kit, link:http://appdev.openshift.io/docs/minishift-installation.html[installed and running], you can deploy your quickstart there.
 
 . Log in to your OpenShift cluster:
 +
@@ -100,16 +97,17 @@ $ oc login -u developer -p developer
 $ oc new-project MY_PROJECT_NAME
 ----
 
-. Import base images in your newly created project (MY_PROJECT_NAME):
+. Configure Red Hat Container Registry authentication (if it is not configured).
+Follow https://access.redhat.com/documentation/en-us/red_hat_fuse/7.9/html-single/fuse_on_openshift_guide/index#configure-container-registry[documentation].
+
+. Import base images in your newly created project (MY_PROJECT_NAME). :
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc import-image fuse-java-openshift:2.0 --from=registry.access.redhat.com/jboss-fuse-7/fuse-java-openshift:2.0 --confirm
+$ oc import-image fuse-java-openshift:1.9 --from=registry.redhat.io/fuse7/fuse-java-openshift:1.9 --confirm
 ----
 
 . Change the directory to the folder that contains the extracted quickstart application (for example, `my_openshift/spring-boot-camel-rest-3scale`) :
-+
-or
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -120,15 +118,15 @@ $ cd my_openshift/spring-boot-camel-rest-3scale
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn clean -DskipTests fabric8:deploy -Popenshift  -Dfabric8.generator.fromMode=istag -Dfabric8.generator.from=MY_PROJECT_NAME/fuse-java-openshift:2.0
+$ mvn clean -DskipTests oc:deploy -Popenshift -Djkube.generator.fromMode=istag -Djkube.generator.from=MY_PROJECT_NAME/fuse-java-openshift:1.9
 ----
 
 . In your browser, navigate to the `MY_PROJECT_NAME` project in the OpenShift console.
 Wait until you can see that the pod for the `spring-boot-camel-rest-3scale` has started up.
 
-. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-rest-3scale` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/pods/spring-boot-camel-rest-3scale-NUMBER_OF_DEPLOYMENT?tab=details`.
+. On the project's `Overview` page, navigate to the details page deployment of the `spring-boot-camel-rest-3scale` application: `https://OPENSHIFT_IP_ADDR:8443/console/project/MY_PROJECT_NAME/browse/rc/spring-boot-camel-rest-3scale-NUMBER_OF_DEPLOYMENT?tab=details`.
 
-. Switch to tab `Logs` and then see the log from Camel.
+. Switch to tab `Logs` and then see the messages sent by Camel.
 
 == Accessing the REST service
 
@@ -172,6 +170,7 @@ $ mvn clean package
 ----
 $ mvn spring-boot:run
 ----
+
 +
 Alternatively, you can run the application locally using the executable JAR produced:
 +
@@ -183,3 +182,7 @@ $ java -jar -Dspring.profiles.active=dev target/spring-boot-camel-rest-3scale-1.
 
 - <http://localhost:8080/camel-rest-3scale/users/greet>
 - <http://localhost:8080/camel-rest-3scale/users/list>
+
+---
+
+Generated by maven plugin - do NOT edit this file! (See https://github.com/jboss-fuse/documentation-template/blob/main/README.md[documentation])

--- a/src/main/doc/introduction.adoc
+++ b/src/main/doc/introduction.adoc
@@ -1,0 +1,19 @@
+= Spring Boot Camel REST 3scale QuickStart
+
+This example demonstrates how to use Camel's REST DSL to expose a RESTful API and expose it to 3scale.
+
+This example relies on the https://maven.fabric8.io[Fabric8 Maven plugin] for its build configuration
+and uses the https://github.com/fabric8io/base-images#java-base-images[fabric8 Java base image].
+
+The Fabric8 Maven Plugin discovers service metadata from Camel XML Context's service definition and exposes the following:
+
+=== Service Label
+* `discovery.3scale.net/discoverable`: Allows 3scale to select Services that are to be automatically exposed.
+
+=== Service Annotations
+* `discovery.3scale.net/discovery-version`: the version of the 3scale discovery process.
+* `discovery.3scale.net/scheme`: this can be http or https
+* `discovery.3scale.net/path`: (optional) the contextPath of the service if it's not at the root.
+* `discovery.3scale.net/description-path`: (optional) the path to the service description document (OpenAPI/Swagger). The path is either relative or an external full URL.
+
+The application utilizes the Spring http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/ImportResource.html[`@ImportResource`] annotation to load a Camel Context definition via a _src/main/resources/spring/camel-context.xml_ file on the classpath.

--- a/src/main/doc/validation-local.adoc
+++ b/src/main/doc/validation-local.adoc
@@ -1,0 +1,11 @@
++
+Alternatively, you can run the application locally using the executable JAR produced:
++
+----
+$ java -jar -Dspring.profiles.active=dev target/spring-boot-camel-rest-3scale-1.0-SNAPSHOT.jar
+----
+
+. You can then access the REST API directly from your Web browser, e.g.:
+
+- <http://localhost:8080/camel-rest-3scale/users/greet>
+- <http://localhost:8080/camel-rest-3scale/users/list>

--- a/src/main/doc/validation-summary.adoc
+++ b/src/main/doc/validation-summary.adoc
@@ -1,0 +1,23 @@
+
+== Accessing the REST service
+
+When the example is running, a REST service is available to list users that have called this service. The user information comes from 3scale extensions to autofill API keys.
+
+* `"x-data-threescale-name": "app_ids"` for the parameter that represents the application ID.
+* `"x-data-threescale-name": "app_keys"` or `"x-data-threescale-name": "user_keys"` for the parameter that represents the application or user key.
+
+Notice: As it depends on your OpenShift setup, the hostname (route) might vary. Verify with `oc get routes` which hostname is valid for you.
+
+The actual endpoint is using the _context-path_ `camel-rest-3scale/users` and the REST service provides two services:
+
+- `users/greet`: to use 3scale API keys to add a user to this service's list of calling users
+- `users/list`: to list all users that have called the service
+
+You can then access these services from your Web browser, e.g.:
+
+- <http://spring-boot-camel-rest-3scale-MY_PROJECT_NAME.OPENSHIFT_IP_ADDR.nip.io/camel-rest-3scale/users/greet>
+- <http://spring-boot-camel-rest-3scale-MY_PROJECT_NAME.OPENSHIFT_IP_ADDR.nip.io/camel-rest-3scale/users/list>
+
+== Swagger API
+
+The example provides API documentation of the service using Swagger using the _context-path_ `camel-rest-3scale/api-doc`. You can access the API documentation from your Web browser at <http://spring-boot-camel-rest-3scale-MY_PROJECT_NAME.OPENSHIFT_IP_ADDR.nip.io/camel-rest-3scale/api-doc>.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14969

Change refactors quickstart to use a template for documentation + template adds missing instruction to add secret.